### PR TITLE
Change max team name length from 30 to 255

### DIFF
--- a/gitea/org_team.go
+++ b/gitea/org_team.go
@@ -138,7 +138,7 @@ func (opt *CreateTeamOption) Validate() error {
 	if len(opt.Name) == 0 {
 		return fmt.Errorf("name required")
 	}
-	if len(opt.Name) > 30 {
+	if len(opt.Name) > 255 {
 		return fmt.Errorf("name to long")
 	}
 	if len(opt.Description) > 255 {


### PR DESCRIPTION
In Gitea _1.22.2_ the 30 character limit on organzation team names is changed to 255 characters. This PR changes a local, to the SDK, check of the length of the name. 